### PR TITLE
Fix developing condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "storybook:build": "storybook build",
     "storybook:test": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npm run storybook -- --no-open\" \"wait-on tcp:6006 && test-storybook\"",
     "e2e": "npx playwright test",
-    "test": "vitest run --silent",
+    "test": "cross-env FEED_A11Y_TEST=1 vitest run --silent",
     "prepare": "husky install"
   },
   "husky": {

--- a/src/Feed.tsx
+++ b/src/Feed.tsx
@@ -392,7 +392,7 @@ function hasAny<T>(target: Array<T>): boolean {
 }
 
 function isDeveloping() {
-  return process.env.NODE_ENV !== 'production'
+  return process.env.NODE_ENV === 'development' || process.env.FEED_A11Y_TEST
 }
 
 const Root = Feed


### PR DESCRIPTION
In addition to the case where env.NODE is development, set environment variables so that the library test is not affected.

**why**: In the previous implementation, the condition is also true if `process.env.NODE_ENV` is `test`. then users could then receive an unintended error when testing their code.